### PR TITLE
New filter type: rank

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Optional parameters to configure include `filter_length`, `filter_type` and `uni
 `unit` can be any string. The default is EUR/kWh/h to reflect that the sensor output loosely speaking reflects change
 rate (1/h) of hourly price (EUR/kWh).
 
-`filter_length` value must be an integer between 2...20, and `filter_type` must be either `triangle` or `rectangle`.
+`filter_length` value must be an integer between 2...20, and `filter_type` must be either `triangle`, `rectangle` or `rank`.
 They are best explained by examples. For illustrative purposes, the following FIRs have been reflected about the time
 axis; the first multiplier corresponds to current hour and the next multipliers correspond to upcoming hours.
 
@@ -70,6 +70,9 @@ price of the next hour. `filter_type` doesn't make a difference in this case.
 And so on. With rectangle, the right side of the filter is "flat". With triangle, the right side is weighting soon
 upcoming hours more than the farther away "tail" hours. First entry is always -1 and the filter is normalized so that
 its sum is zero. This way the characteristic output magnitude is independent of the settings.
+
+With `filter_type: rank`, the current price is ranked amongst the next `filter_length` prices. The lowest price is given
+a value of `1`, the highest prices is given the value of `-1`, and the other prices are equally distributed in this interval.
 
 You can set up several `nordpool_diff` entities, each with different parameters, plot them in Lovelace, and pick what
 you like best. Here is an example:

--- a/custom_components/nordpool_diff/manifest.json
+++ b/custom_components/nordpool_diff/manifest.json
@@ -7,5 +7,5 @@
   "dependencies": ["nordpool"],
   "codeowners": ["@jpulakka"],
   "iot_class": "calculated",
-  "version": "0.1.0"
+  "version": "0.1.1"
 }

--- a/custom_components/nordpool_diff/sensor.py
+++ b/custom_components/nordpool_diff/sensor.py
@@ -81,7 +81,7 @@ class NordpoolDiffSensor(SensorEntity):
         return {"next_hour": self._next_hour}
 
     def update(self):
-        prices = self._get_next_n_hours(self._filter_length)  # +1 to calculate next hour
+        prices = self._get_next_n_hours(self._filter_length + 1)  # +1 to calculate next hour
         self._state = round(self._compute(prices[:-1]), 3)
         self._next_hour = round(self._compute(prices[1:]), 3)
 


### PR DESCRIPTION
### Problem

I have set up my water heater to only turn on if `nordpool_diff_rectangle_10 > .66`. However, on days with low price variation, this never occurs, so the water heater will never turn on.

### Solution

If I additionally turn on the water heater if the prices is among the 2 lowest of the next 10 hours, it will also turn on when the (absolute) price variation is small.

There is still a corner case left; when the price is slowly decreasing, so I think I will also have to turn it on if it has stayed off for more than 16 hours (say).



Even though this new filter type is strictly not a FIR differentiator, the framework of retrieving prices was very handy to reuse for this filter, so I hope it is a welcome addition.