### PR TITLE
Updated range and default value of filter_length

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Nordpool Diff is not suitable for controlling washing machines, dishwashers and 
   	sensor:
         - platform: nordpool_diff
       	nordpool_entity: [your nordpool price sensor, for example sensor.nordpool_kwh_fi_eur_3_095_024]
-      	filter_length: 10
+      	filter_length: 40
       	normalize: max_min_sqrt_max
   	```
 4. Restart Home Assistant again
@@ -52,7 +52,7 @@ The following parameters can be added to the sensor:
 |`nordpool_entity`|  |  | Your Nordpool sensor, for example `sensor.nordpool_kwh_fi_eur_3_095_024`. Mandatory if you use Nordpool. |
 |`entsoe_entity`|  | `sensor.average_electricity_price_today` | Your Entso-E sensor, if you've named it during installation|
 |`filter_type`| `triangle`, `rectangle`, `rank`, `interval` | `triangle`| See next chapters|
-|`filter_length`| 2...20 | `10`| Defines how many hours into the future to consider|
+|`filter_length`| 2...80 | `40`| Defines how many quarters into the future to consider|
 |`normalize`| `no`, `max`, `max_min`, `sqrt_max`, `max_min_sqrt_max`| `no`| How to normalize the output of  `triangle` and `rectangle` filters. See [`Normalization` option](#normalization).|
 |`unit`| | `EUR/kWh/h`|  The unit of the sensor. Loosely speaking reflects rate of change (1/h) of hourly price (EUR/kWh)|
 

--- a/custom_components/nordpool_diff/sensor.py
+++ b/custom_components/nordpool_diff/sensor.py
@@ -35,7 +35,7 @@ UNIT = "unit"
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(NORDPOOL_ENTITY, default=""): cv.string,  # Is there a way to require EITHER nordpool OR entsoe being valid cv.entity_id?
     vol.Optional(ENTSOE_ENTITY, default="sensor.average_electricity_price_today"): cv.string,  # hass-entso-e's default entity id
-    vol.Optional(FILTER_LENGTH, default=10): vol.All(vol.Coerce(int), vol.Range(min=2, max=20)),
+    vol.Optional(FILTER_LENGTH, default=40): vol.All(vol.Coerce(int), vol.Range(min=2, max=80)),
     vol.Optional(FILTER_TYPE, default=TRIANGLE): vol.In([RECTANGLE, TRIANGLE, INTERVAL, RANK]),
     vol.Optional(NORMALIZE, default=NO): vol.In([NO, MAX, MAX_MIN, SQRT_MAX, MAX_MIN_SQRT_MAX]),
     vol.Optional(UNIT, default="EUR/kWh/h"): cv.string


### PR DESCRIPTION
Updated range and default value of filter_length to support the same range as before changing to 15minute intervals from hours (see #33)